### PR TITLE
chore: move the website to be deployed through Zeit Now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ yarn-error.log
 # Yarn Integrity file
 .yarn-integrity
 yarn.lock
+
+now.json

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Portfolio for developers
 
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/smakosh/gatsby-portfolio-dev)
+
 [![Netlify Status](https://api.netlify.com/api/v1/badges/57c04515-1d1b-46e8-b531-213fabca9cc4/deploy-status)](https://app.netlify.com/sites/gatsby-portfolio-dev/deploys)
 
 ## Theme
+
 [Gatsby-theme-portfolio](https://github.com/smakosh/gatsby-theme-portfolio)
 
 ## Features


### PR DESCRIPTION
## What's new?
- Migrate to Zeit Now
> You can still deploy it to Netlify without any issues, for Zeit Now, just hit the button on the README file.