### PR TITLE
fix 🛠: image url reference for footer background

### DIFF
--- a/src/components/theme/Footer/styles.js
+++ b/src/components/theme/Footer/styles.js
@@ -1,8 +1,9 @@
+import footerIllustration from 'assets/illustrations/footer.svg';
 import styled from 'styled-components';
 
 export const Wrapper = styled.div`
   padding: 28rem 0 4rem 0;
-  background-image: url('../illustrations/footer.svg');
+  background-image: url(${footerIllustration});
   background-size: cover;
   background-position: top;
   background-repeat: no-repeat;


### PR DESCRIPTION
use correct url reference that can be resolved properly at build time similar to the one used in `Intro - styles.js` and `Skills - styles.js`