### PR TITLE
remove yarn.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,5 @@ yarn-error.log
 .pnp.js
 # Yarn Integrity file
 .yarn-integrity
-yarn.lock
 
 now.json


### PR DESCRIPTION
`yarn.lock` [should](https://classic.yarnpkg.com/en/docs/migrating-from-npm) be part of the repository