### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 	"resolutions": {
 		"graphql": "^15.4.0",
 		"graphql-compose": "^7.25.0",
-		"webpack": "^5.24.2"
+		"webpack": "^5.24.2",
+		"formik/deepmerge": "4.2.2"
 	}
 }


### PR DESCRIPTION
The project won't build because since Gastby version 3.13.1
The package deepmerge is required.

However formik is using an old version of it that breaks the build process.

Original issue: https://github.com/formium/formik/pull/3353